### PR TITLE
Fix some typos in documentation

### DIFF
--- a/demo/README.adoc
+++ b/demo/README.adoc
@@ -19,7 +19,7 @@ By default RHEL/Centos sets the max_user_namespaces value to **0**, you need to 
 ----
 minishift ssh
 sudo -i
-echo "sysctl user.max_user_namespaces=15000" >> /etc/sysctl.d/99-sysctl.conf
+echo "user.max_user_namespaces=15000" >> /etc/sysctl.d/99-sysctl.conf
 sysctl -p
 ----
 save the value permanently surviving reboots


### PR DESCRIPTION
Remove `sysctl` command from 99-sysctl.conf otherwise it ends with 
```
sysctl: cannot stat /proc/sys/sysctl user/max_user_namespaces: No such file or directory
```
when persisting changes.